### PR TITLE
fix unifi router for access to local cloud key

### DIFF
--- a/appdata/traefik2/rules/app-unifi.toml.example
+++ b/appdata/traefik2/rules/app-unifi.toml.example
@@ -1,16 +1,14 @@
-[tcp.routers]
-  [tcp.routers.unifi-rtr]
+[http.routers]
+  [http.routers.unifi-rtr]
       entryPoints = ["https"]
-      rule = "HostSNI(`unifi.example.com`)" # will only work with cloudflare Full SSL (not Strict)
+      rule = "Host(`unifi.example.com`)" # will only work with cloudflare Full SSL (not Strict)
       service = "unifi-svc"
       middlewares = ["chain-authelia"]
-      [tcp.routers.unifi-rtr.tls]
+      [http.routers.unifi-rtr.tls]
         certresolver = "dns-cloudflare"
-        passthrough = true
-[tcp.services]
-  [tcp.services.unifi-svc]
-    [tcp.services.unifi-svc.loadBalancer]
+[http.services]
+  [http.services.unifi-svc]
+    [http.services.unifi-svc.loadBalancer]
       passHostHeader = true
-      [[tcp.services.unifi-svc.loadBalancer.servers]]
-        address = "192.168.5.254:8443"
-
+      [[http.services.unifi-svc.loadBalancer.servers]]
+        "https://192.168.5.254:8443" # or whatever your external host's IP:port is 

--- a/appdata/traefik2/rules/app-unifi.yml.example
+++ b/appdata/traefik2/rules/app-unifi.yml.example
@@ -1,7 +1,7 @@
-tcp:
+http:
   routers:
     unifi-rtr:
-      rule: "HostSNI(`unifi.example.com`)" # will only work with cloudflare Full SSL (not Strict)
+      rule: "Host(`unifi.example.com`)" # will only work with cloudflare Full SSL (not Strict)
       entryPoints:
         - https
       middlewares:
@@ -9,10 +9,9 @@ tcp:
       service: unifi-svc
       tls:
         certResolver: dns-cloudflare
-        passthrough: true
   services:
     unifi-svc:
       loadBalancer:
+        passHostHeader: true
         servers:
-          - address: "192.168.5.254:8443"
-
+          - address: "https://192.168.5.254:8443" # or whatever your external host's IP:port is 


### PR DESCRIPTION
This pull request fixes traefik routing to a Unifi Cloudkey Gen2+ using traefik.

The current repo uses a TCP router which fails. This will switch it to the correct HTTP router, and redirect all traffic to HTTPS.

*Note: Cloudflare SSL must be set to Full not Full (Strict)