### PR TITLE
Updated Authelia to used required storage encryption secret

### DIFF
--- a/docker-compose-t2.yml
+++ b/docker-compose-t2.yml
@@ -47,6 +47,8 @@ secrets:
     file: $DOCKERDIR/secrets/authelia_notifier_smtp_password
   authelia_duo_api_secret_key:
     file: $DOCKERDIR/secrets/authelia_duo_api_secret_key
+  authelia_storage_encryption_key:
+    file: $DOCKERDIR/secrets/authelia_storage_encryption_key
   oauth_secret:
     file: $DOCKERDIR/secrets/oauth_secret
   google_client_secret:
@@ -67,7 +69,7 @@ secrets:
     file: $DOCKERDIR/secrets/traefik_pilot_token
   mysql_root_password:
     file: $DOCKERDIR/secrets/mysql_root_password
-
+  
 ########################### SERVICES
 services:
   ############################# FRONTENDS
@@ -305,12 +307,14 @@ services:
       - AUTHELIA_STORAGE_MYSQL_PASSWORD_FILE=/run/secrets/authelia_storage_mysql_password
       - AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE=/run/secrets/authelia_notifier_smtp_password
       - AUTHELIA_DUO_API_SECRET_KEY_FILE=/run/secrets/authelia_duo_api_secret_key
+      - AUTHELIA_STORAGE_ENCRYPTION_KEY_FILE=/run/secrets/authelia_storage_encryption_key
     secrets:
       - authelia_jwt_secret
       - authelia_session_secret
       - authelia_storage_mysql_password
       - authelia_notifier_smtp_password
       - authelia_duo_api_secret_key
+      - authelia_storage_encryption_key
     labels:
       - "traefik.enable=true"
       ## HTTP Routers


### PR DESCRIPTION
[Authelia 4.33.0+](https://github.com/authelia/authelia/releases/tag/v4.33.0) brought a new requirement of using an encryption key for storage backends. This PR simply addresses this requirement by adding the encryption key as a secret.
[Authelia Documentation](https://www.authelia.com/docs/configuration/storage/#encryption_key) regarding storage backend encryption keys for further reading.

Thanks!!

