### PR TITLE
Create traefik-forward-auth

### DIFF
--- a/secrets_example/traefik-forward-auth
+++ b/secrets_example/traefik-forward-auth
@@ -1,0 +1,8 @@
+### EXAMPLE OF REQUIRED FILE TO ALLOW DOCKER SECRETS TO FUNCTION WITH GOOGLE OAUTH
+### FOR FURTHER DETAILS SEE https://github.com/thomseddon/traefik-forward-auth
+
+providers.google.client-id=yourGOOGLEclientID
+providers.google.client-secret=yourCLIENTsecret
+secret=RANDOMcharacters
+whitelist=yourEMAILaddress
+whitelist=yourEMAILaddress2


### PR DESCRIPTION
An example file that needs to be stored in the docker secrets directory in order for docker secrets to be functional.