### PR TITLE
Add extension field for common environment variables

### DIFF
--- a/.bash_aliases.example
+++ b/.bash_aliases.example
@@ -13,8 +13,10 @@ alias dcrm='dcrun rm'
 alias docdf='sudo docker system df'
 alias dclogs='sudo docker logs -tf --tail="50" '
 alias fixsecrets='sudo chown -R root:root /home/USER/docker/secrets ; sudo chmod -R 600 /home/USER/docker/secrets'
-# depends on having jq installed, but makes it so much easier
-alias doips="sudo docker ps -q | xargs -n 1 docker inspect --format '{{json .}}' | jq -rs 'map(.Name,.NetworkSettings.Networks[].IPAddress) | .[]'"
+# depends on having column installed for table formatting, sorted by name
+alias doips="sudo docker ps -q | xargs -n 1 docker inspect -f '{{.Name}}%tab%{{range .NetworkSettings.Networks}}{{.IPAddress}}%tab%{{end}}' | sed 's#%tab%#\t#g' | sed 's#/##g' | sort | column -t -N NAME,IP\(s\) -o $'\t'"
+# sorted by first IP
+alias doipsi="sudo docker ps -q | xargs -n 1 docker inspect -f '{{.Name}}%tab%{{range .NetworkSettings.Networks}}{{.IPAddress}}%tab%{{end}}' | sed 's#%tab%#\t#g' | sed 's#/##g' | sort -t . -k 1,1n -k 2,2n -k 3,3n -k 4,4n | column -t -N NAME,IP\(s\) -o $'\t'"
 doip() {
   sudo docker inspect --format '{{json .}}' "$1" | jq -rs 'map(.NetworkSettings.Networks[].IPAddress) | .[]'
 }

--- a/docker-compose-t2.yml
+++ b/docker-compose-t2.yml
@@ -57,6 +57,12 @@ secrets:
   guac_mysql_password:
     file: $DOCKERDIR/secrets/guac_mysql_password
 
+########################### EXTENSION FIELDS
+x-environment: &default-tz-puid-pgid
+  TZ: $TZ
+  PUID: $PUID
+  PGID: $PGID
+
 ########################### SERVICES
 services:
   ############################# FRONTENDS
@@ -394,15 +400,13 @@ services:
       - $DOCKERDIR/appdata/transmission-vpn/config:/config
       - $DATADIR/downloads:/data/downloads
     environment:
+      << : *default-tz-puid-pgid
       OPENVPN_PROVIDER: FASTESTVPN
       OPENVPN_USERNAME: $FASTEST_USERNAME
       OPENVPN_PASSWORD: $FASTEST_PASSWORD
       #OPENVPN_CONFIG: "Switzerland-UDP"
       #OPENVPN_OPTS: --inactive 3600 --ping 10 --ping-exit 60
       LOCAL_NETWORK: "$LOCAL_NETWORK"
-      PUID: $PUID
-      PGID: $PGID
-      TZ: $TZ
       UMASK_SET: 2
       TRANSMISSION_RPC_AUTHENTICATION_REQUIRED: "true"
       TRANSMISSION_RPC_HOST_WHITELIST: "127.0.0.1,$SERVER_IP"
@@ -452,9 +456,7 @@ services:
       - $DOCKERDIR/appdata/qbittorrent:/config
       - $DATADIR/downloads:/downloads
     environment:
-      PUID: $PUID
-      PGID: $PGID
-      TZ: $TZ
+      << : *default-tz-puid-pgid
       UMASK_SET: 002
       WEBUI_PORT: 8168
     labels:
@@ -486,9 +488,7 @@ services:
       - $DOCKERDIR/appdata/nzbget:/config
       - $DATADIR/downloads:/data/downloads
     environment:
-      PUID: $PUID
-      PGID: $PGID
-      TZ: $TZ
+      << : *default-tz-puid-pgid
     labels:
       - "traefik.enable=true"
       ## HTTP Routers Auth Bypass
@@ -532,9 +532,7 @@ services:
       - $DATADIR/downloads:/data/downloads
       - "/etc/localtime:/etc/localtime:ro"
     environment:
-      PUID: $PUID
-      PGID: $PGID
-      TZ: $TZ
+      << : *default-tz-puid-pgid
     labels:
       - "traefik.enable=true"
       ## HTTP Routers
@@ -565,9 +563,7 @@ services:
       - $DOCKERDIR/appdata/prowlarr:/config
       - "/etc/localtime:/etc/localtime:ro"
     environment:
-      PUID: $PUID
-      PGID: $PGID
-      TZ: $TZ
+      << : *default-tz-puid-pgid
     labels:
       - "traefik.enable=true"
       ## HTTP Routers
@@ -596,9 +592,7 @@ services:
       - $DOCKERDIR/appdata/hydra2:/config
       - $DATADIR/downloads:/data/downloads
     environment:
-      PUID: $PUID
-      PGID: $PGID
-      TZ: $TZ
+      << : *default-tz-puid-pgid
     labels:
       - "traefik.enable=true"
       ## HTTP Routers
@@ -635,9 +629,7 @@ services:
       - $DATADIR/media/music:/data/media/music
       - "/etc/localtime:/etc/localtime:ro"
     environment:
-      PUID: $PUID
-      PGID: $PGID
-      TZ: $TZ
+      << : *default-tz-puid-pgid
     labels:
       - "traefik.enable=true"
       ## HTTP Routers Auth Bypass
@@ -679,9 +671,7 @@ services:
       - $DATADIR/media:/data/media
       - "/etc/localtime:/etc/localtime:ro"
     environment:
-      PUID: $PUID
-      PGID: $PGID
-      TZ: $TZ
+      << : *default-tz-puid-pgid
     labels:
       - "traefik.enable=true"
       ## HTTP Routers Auth Bypass
@@ -723,9 +713,7 @@ services:
       - $DATADIR/media:/data/media
       - "/etc/localtime:/etc/localtime:ro"
     environment:
-      PUID: $PUID
-      PGID: $PGID
-      TZ: $TZ
+      << : *default-tz-puid-pgid
     labels:
       - "traefik.enable=true"
       ## HTTP Routers Auth Bypass
@@ -764,9 +752,7 @@ services:
       - $DATADIR/media/books:/data/media/books
       - "/etc/localtime:/etc/localtime:ro"
     environment:
-      PUID: $PUID
-      PGID: $PGID
-      TZ: $TZ
+      << : *default-tz-puid-pgid
       UMASK: 002
       #ARGS: ""
     labels:
@@ -866,9 +852,7 @@ services:
       - "$JELLYFIN_PORT:8096"
       - "8920:8920" # Emby also uses same port if running both
     environment:
-      PUID: $PUID
-      PGID: $PGID
-      TZ: $TZ
+      << : *default-tz-puid-pgid
       UMASK_SET: 022
     volumes:
       - $DOCKERDIR/appdata/jellyfin:/config
@@ -907,9 +891,7 @@ services:
       - $DOCKERDIR/appdata/bazarr:/config
       - $DATADIR/media:/data/media
     environment:
-      PUID: $PUID
-      PGID: $PGID
-      TZ: $TZ
+      << : *default-tz-puid-pgid
     labels:
       - "traefik.enable=true"
       ## HTTP Routers Auth Bypass
@@ -1369,9 +1351,7 @@ services:
       - $USERDIR:/data/home
       - $DOCKERDIR/appdata/syncthing:/config
     environment:
-      PUID: $PUID
-      PGID: $PGID
-      TZ: $TZ
+      << : *default-tz-puid-pgid
     labels:
       - "traefik.enable=true"
       ## HTTP Routers


### PR DESCRIPTION
I'm quite a fan of not repeating myself. I see you are using a few environment variables quite often such as `$PUID`, `$PGID` and `$TZ`.

I like using extension fields to get rid of these repetitions: https://docs.docker.com/compose/compose-file/compose-file-v3/#extension-fields, or better explained here: https://medium.com/@kinghuang/docker-compose-anchors-aliases-extensions-a1e4105d70bd

I took the liberty of creating one extension field (I do have a couple more) for replacing these common environment variables:
```yaml
########################### EXTENSION FIELDS
x-environment: &default-tz-puid-pgid
  TZ: $TZ
  PUID: $PUID
  PGID: $PGID
```
They can be used by just dropping this line `<< : *default-tz-puid-pgid` instead of an environment variable.