### PR TITLE
Update docker-compose-t2.yml

### DIFF
--- a/docker-compose-t2.yml
+++ b/docker-compose-t2.yml
@@ -47,14 +47,8 @@ secrets:
     file: $DOCKERDIR/secrets/authelia_notifier_smtp_password
   authelia_duo_api_secret_key:
     file: $DOCKERDIR/secrets/authelia_duo_api_secret_key
-  oauth_secret:
-    file: $DOCKERDIR/secrets/oauth_secret
-  google_client_secret:
-    file: $DOCKERDIR/secrets/google_client_secret
-  google_client_id:
-    file: $DOCKERDIR/secrets/google_client_id
-  my_email:
-    file: $DOCKERDIR/secrets/my_email
+  traefik-forward-auth:
+    file: $SECRETSDIR/traefik-forward-auth
   plex_claim:
     file: $DOCKERDIR/secrets/plex_claim
   guac_db_name:
@@ -253,14 +247,11 @@ services:
     # command: --rule.radarr.action=allow --rule.radarr.rule="Headers(`X-Api-Key`, `$RADARR_API_KEY`)"
     # command: --rule.sabnzbd.action=allow --rule.sabnzbd.rule="HeadersRegexp(`X-Forwarded-Uri`, `$SABNZBD_API_KEY`)"
     environment:
-      - PROVIDERS_GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID
-      - PROVIDERS_GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
-      - SECRET=$OAUTH_SECRET
+      - CONFIG=/config
       - COOKIE_DOMAIN=$DOMAINNAME0
       - INSECURE_COOKIE=false
       - AUTH_HOST=oauth.$DOMAINNAME0
       - URL_PATH=/_oauth
-      - WHITELIST=$MY_EMAIL
       - LOG_LEVEL=warn
       - LOG_FORMAT=text
       - LIFETIME=86400 # 1 day


### PR DESCRIPTION
First, my apologies as I didn't pay attention when I pasted the changes into my branch.  It should have made more changes than just the secrets definition.  It's important to note that this allows you to leverage secrets, but it will be the variables (email, google client id, etc) defined within the traefik-forward-auth file in the secrets directory.  Here is a summary of the changes in the pull request:

The secrets for the Oauth container are stored in the SECRETS directory for your Docker instance. ($SECRETSDIR)  (In a file called traefik-forward-auth)  Therefore, there is no need to call those secrets within the compose file.  So in the initial secrets definition section, we remove the oauth_secret, google_client_secret, google_client_id, and my_email.  From here, we create a secret called traefik-forward-auth and define its file path within the secrets directory:
  traefik-forward-auth:
    file: $SECRETSDIR/traefik-forward-auth

We then remove the references of the environment variables within the container section of the compose file in the environment section.  ($GOOGLE_CLIENT_ID, $GOOGLE_CLIENT_SECRET, $OAUTH_SECRET, $MY_EMAIL)

We need to make one addition to the environment section:  CONFIG=/config

Since Google Oauth leverages an ini file, it requires accessing the /config directory for source files.

At this point, the only thing needed is the reference to the config path (where traefik-forward-auth is called), which has already been committed to the compose file:
  
     secrets:
      - source: traefik-forward-auth
        target: /config