### PR TITLE
Rename socket_proxy to zsocket_proxy

### DIFF
--- a/docker-compose-t2.yml
+++ b/docker-compose-t2.yml
@@ -25,8 +25,11 @@ networks:
         - subnet: 192.168.90.0/24
   default:
     driver: bridge
-  socket_proxy:
-    name: socket_proxy
+   # docker-compose nuisance: networks are assigned interfaces based on alphabetical order in docker compose V3
+   # see https://github.com/docker/cli/issues/1372
+   # we want our default gateway in containers to be default > traefik > socket proxy, hence socket proxy gets a 'z' prefix
+  zsocket_proxy:
+    name: zsocket_proxy
     driver: bridge
     ipam:
       config:
@@ -171,7 +174,7 @@ services:
     networks:
       t2_proxy:
         ipv4_address: 192.168.90.254 # You can specify a static IP
-      socket_proxy:
+      zsocket_proxy:
     #healthcheck:
     #  test: ["CMD", "traefik", "healthcheck", "--ping"]
     #  interval: 5s
@@ -228,7 +231,7 @@ services:
     container_name: socket-proxy
     image: tecnativa/docker-socket-proxy
     networks:
-      socket_proxy:
+      zsocket_proxy:
         ipv4_address: 192.168.91.254 # You can specify a static IP
     privileged: true
     #ports:
@@ -361,7 +364,7 @@ services:
     command: -H tcp://socket-proxy:2375
     networks:
       - t2_proxy
-      - socket_proxy
+      - zsocket_proxy
     volumes:
       # - /var/run/docker.sock:/var/run/docker.sock:ro # # Use Docker Socket Proxy instead for improved security
       - $DOCKERDIR/appdata/portainer/data:/data # Change to local directory if you want to save/transfer config locally
@@ -1162,7 +1165,7 @@ services:
     # network_mode: host
     networks:
       - t2_proxy
-      - socket_proxy
+      - zsocket_proxy
       - default
     # ports:
     #   - "$GLANCES_PORT:61208"
@@ -1227,7 +1230,7 @@ services:
     container_name: dozzle
     networks:
       - t2_proxy
-      - socket_proxy
+      - zsocket_proxy
     # ports:
     #   - "$DOZZLE_PORT:8080"
     environment:
@@ -1314,7 +1317,7 @@ services:
     image: clockworksoul/docker-gc-cron:latest
     container_name: docker-gc
     networks:
-      - socket_proxy
+      - zsocket_proxy
     volumes:
       # - /var/run/docker.sock:/var/run/docker.sock # Use Docker Socket Proxy instead for improved security
       - $DOCKERDIR/appdata/docker-gc/docker-gc-exclude:/etc/docker-gc-exclude
@@ -1334,7 +1337,7 @@ services:
     container_name: cf-companion
     image: tiredofit/traefik-cloudflare-companion:latest
     networks:
-      - socket_proxy
+      - zsocket_proxy
     environment:
       - TIMEZONE=$TZ
       - TRAEFIK_VERSION=2


### PR DESCRIPTION
docker-compose v2 had network priority, unfortunately docker-compose v3 does not have this functionality (yet?). See https://github.com/docker/cli/issues/1372

Networks are assigned to containers using alphabetical order, in this case it means that "socket_proxy" is always ordered before "t2_proxy", this in turn means that the default gateway in containers is always the "socket_proxy" gateway and therefore the outgoing IP address to other containers. I believe this is wrong and the outgoing containers' IPs should always be the default networks gateway and respective IP as well as the traefik containers' IP - never the socket-proxy IP.

I recently ran into this problem due to Authelia refusing oauth requests from container-to-container since I didn't allow the socket-proxy network to communicate via Authelia (because why should it, it should always just be container <-> docker sock).

Taking the traefik container as an example:

### Before the change

```shell
$  docker exec traefik route
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
default         192.168.91.1    0.0.0.0         UG    0      0        0 eth0
192.168.90.0    *               255.255.255.0   U     0      0        0 eth1
192.168.91.0    *               255.255.255.0   U     0      0        0 eth0
```

### After the change
(note the assignment of eth0/eth1)

```shell
$  docker exec traefik route
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
default         192.168.90.1    0.0.0.0         UG    0      0        0 eth0
192.168.90.0    *               255.255.255.0   U     0      0        0 eth0
192.168.91.0    *               255.255.255.0   U     0      0        0 eth1
```

This could have been changed in docker-compose v2 with the `priority` attribute (assigning e.g. `priority: 10` to the traefik proxy network), but this just doesn't work with docker-compose v3. 😐