### PR TITLE
Take advantage of hardlinks in *arr apps

### DIFF
--- a/docker-compose-t2.yml
+++ b/docker-compose-t2.yml
@@ -601,7 +601,7 @@ services:
     #   - "$QBITTORRENT_PORT:8080"
     volumes:
       - $DOCKERDIR/appdata/qbittorrent:/config
-      - $DATADIR/downloads:/downloads
+      - $DATADIR/downloads:/data/downloads # Ensure that downloads folder is set to /data/downloads in qBittorrent
     environment:
       <<: *default-tz-puid-pgid
       UMASK_SET: 002
@@ -778,8 +778,7 @@ services:
       - $DOCKERDIR/appdata/radarr:/config
       # Optional. See why MediaCover is mounted as volume https://github.com/htpcBeginner/docker-traefik/discussions/147
       - $DATADIR/temp/appdata/radarr/MediaCover:/config/MediaCover
-      - $DATADIR/downloads:/data/downloads
-      - $DATADIR/media:/data/media
+      - $DATADIR:/data
       - "/etc/localtime:/etc/localtime:ro"
     environment:
       <<: *default-tz-puid-pgid
@@ -816,8 +815,7 @@ services:
       - $DOCKERDIR/appdata/sonarr:/config
       # Optional. See why MediaCover is mounted as volume https://github.com/htpcBeginner/docker-traefik/discussions/147
       - $DATADIR/temp/appdata/sonarr/MediaCover:/config/MediaCover
-      - $DATADIR/downloads:/data/downloads
-      - $DATADIR/media:/data/media
+      - $DATADIR:/data
       - "/etc/localtime:/etc/localtime:ro"
     environment:
       <<: *default-tz-puid-pgid
@@ -849,8 +847,7 @@ services:
     #  - "$READARR_PORT:8787"
     volumes:
       - $DOCKERDIR/appdata/readarr:/config
-      - $DATADIR/downloads:/data/downloads
-      - $DATADIR/media/books:/data/media/books
+      - $DATADIR:/data
       - "/etc/localtime:/etc/localtime:ro"
     environment:
       <<: *default-tz-puid-pgid

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,8 +238,7 @@ services:
       - "7878:7878"
     volumes:
       - $DOCKERDIR/appdata/radarr:/config
-      - $DATADIR/downloads:/data/downloads
-      - $DATADIR/media:/data/media
+      - $DATADIR:/data
       - "/etc/localtime:/etc/localtime:ro"
     environment:
       <<: *default-tz-puid-pgid
@@ -256,8 +255,7 @@ services:
       - "8989:8989"
     volumes:
       - $DOCKERDIR/appdata/sonarr:/config
-      - $DATADIR/downloads:/data/downloads
-      - $DATADIR/media:/data/media
+      - $DATADIR:/data
       - "/etc/localtime:/etc/localtime:ro"
     environment:
       <<: *default-tz-puid-pgid
@@ -271,8 +269,7 @@ services:
       - "8987:8987"
     volumes:
       - $DOCKERDIR/appdata/readarr:/config
-      - $DATADIR/downloads:/data/downloads
-      - $DATADIR/media/books:/data/media/books
+      - $DATADIR:/data
       - "/etc/localtime:/etc/localtime:ro"
     environment:
       <<: *default-tz-puid-pgid


### PR DESCRIPTION
Hardlinks makes importing files instant, and allows seeding torrents without using twice the storage. 

Docker containers treat each mounted volume as a separate filesystem, to utilize hardlinks the mounted volume should contain the downloads and media directories, instead of two different volume mounts.

Those changes should work automatically without any manual intervention from the user, I have tested this setup for around 2 months.

Note: Lidarr uses a different path than the rest of the stack ```$DATADIR/local/music:/data/media/music``` so I did not change the volumes, as it would require manual intervention. It should be ```$DATADIR/media/music:/data/media/music``` to be consistent with the rest of the stack.
