### PR TITLE
Fix for NBZGet bypass for use with NZB360

### DIFF
--- a/docker-compose-t2.yml
+++ b/docker-compose-t2.yml
@@ -650,8 +650,7 @@ services:
       ## HTTP Routers Auth Bypass
       - "traefik.http.routers.nzbget-rtr-bypass.entrypoints=https"
       # BYPASS IS NOT WORKING YET. NEED TO FIGURE THIS OUT.
-      - "traefik.http.routers.nzbget-rtr-bypass.rule=Host(`nzbget.$DOMAINNAME_CLOUD_SERVER`)"
-      #- "traefik.http.routers.nzbget-rtr-bypass.rule=Host(`nzbget.$DOMAINNAME_CLOUD_SERVER`) && Query(`apikey`, `$NZBGET_API_KEY`)"
+      - "traefik.http.routers.nzbget-rtr-bypass.rule=Host(`nzbget.$DOMAINNAME_CLOUD_SERVER`) && (Headers(`authorization`, `Basic $NZBGET_KEY`))"
       - "traefik.http.routers.nzbget-rtr-bypass.priority=100"
       ## HTTP Routers Auth
       - "traefik.http.routers.nzbget-rtr.entrypoints=https"


### PR DESCRIPTION
Use https://www.base64encode.org/ to encode an nzbget_key in the form of user:password, the same one you use to log into nbzget

Then in NBZ360 use the url https://user:password@nzbget.mydomain.com as your primary connection address. This should now bypass auth.