### PR TITLE
Unifi using self signed cert causes HTTP 500 errors

### DIFF
--- a/appdata/traefik2/rules/toml/app-unifi.toml.example
+++ b/appdata/traefik2/rules/toml/app-unifi.toml.example
@@ -9,6 +9,9 @@
 [http.services]
   [http.services.unifi-svc]
     [http.services.unifi-svc.loadBalancer]
-      passHostHeader = true
+      serversTransport = "skipSSLVerify"
       [[http.services.unifi-svc.loadBalancer.servers]]
-        "https://192.168.5.254:8443" # or whatever your external host's IP:port is 
+        "https://192.168.5.254:8443" # or whatever your external host's IP:port is
+  [http.services.serversTransports]
+    [http.services.serversTransports.skipSSLVerify]    
+      insecureSkipVerify = true


### PR DESCRIPTION
Since Ubiquity is using self signed certs and forces HTTPS we need to skip SSL verification.

I haven't tested this TOML since I am using YAML, but it should work like this. Also to note: This creates a global "skipSSLVerify" `serversTransport` and this might be better suited in its own TOML file instead of hidden inside this unifi toml because maybe other internal services also serve non-verifiable SSL.