### PR TITLE
Update users_database.yml.example

### DIFF
--- a/appdata/authelia/users_database.yml.example
+++ b/appdata/authelia/users_database.yml.example
@@ -3,7 +3,7 @@
 ###############################################################
 
 # This file can be used if you do not have an LDAP set up.
-# Create new hashed password: docker run authelia/authelia:latest authelia hash-password <new_password>
+# Create new hashed password: docker run authelia/authelia:latest authelia hash-password -- <new_password>
 # https://docs.authelia.com/configuration/authentication/file.html
 
 # List of users


### PR DESCRIPTION
Using the command as currently provided results in an error:

Error: failed to read the password from the terminal: you must either use an interactive terminal or use the --password flag

We need to add a "--" between the command and the password to work now:

Usage:
  authelia hash-password [flags] -- [password]

Examples:
authelia hash-password -- 'mypass'
authelia hash-password --sha512 -- 'mypass'
authelia hash-password --iterations=4 -- 'mypass'
authelia hash-password --memory=128 -- 'mypass'
authelia hash-password --parallelism=1 -- 'mypass' authelia hash-password --key-length=64 -- 'mypass'

Flags:
  -c, --config strings    configuration files to load (default [configuration.yml])
  -h, --help              help for hash-password
  -i, --iterations int    set the number of hashing iterations (default 3)
  -k, --key-length int    [argon2id] set the key length param (default 32)
  -m, --memory int        [argon2id] set the amount of memory param (in MB) (default 65536)
      --no-confirm        skip the password confirmation prompt
  -p, --parallelism int   [argon2id] set the parallelism param (default 4)
  -l, --salt-length int   set the auto-generated salt length (default 16)
  -z, --sha512            use sha512 as the algorithm (changes iterations to 50000, change with -i)