### PR TITLE
Added "decluttarr" (radarr/sonarr/lidarr/readarr queue cleaner) under "Media File Management"

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ Some apps are used in more than one host and some on only one.
 - MakeMKV - Video Editing (Ripping from Disks)
 - FileBot - File renamer
 - Tiny Media Manager - Media Files Management
-
+- [Decluttarr](https://github.com/ManiMatter/decluttarr/) - Queue cleaner for radarr/sonarr/lidarr/readarr
+  
 ### UTILITIES
 
 - Firefox - Web Broswerstack


### PR DESCRIPTION
Decluttarr watches radarr, sonarr, lidarr and readarr download queues and removes downloads if they become stalled or no longer needed.


Hope you find this a helpful addition to your stack.